### PR TITLE
Fix OpenCheckoutOptions Type per Documentation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,14 +25,14 @@ type InitOptions = {
 };
 
 type OpenCheckoutOptions = {
-  hostedPage: Function;
-  layout: Layout;
-  loaded: Function;
-  error: Function;
-  success(hostedPageId: string): void;
-  close: Function;
-  step(currentStep: string): void;
-};
+  hostedPage(): Promise<HostedPage>
+  layout?: Layout
+  loaded?: Function
+  error?: Function
+  success?(hostedPageId: string): void
+  close?: Function
+  step?(currentStep: string): void
+}
 
 interface AddressDetails {
   first_name?: string;
@@ -559,4 +559,14 @@ export interface Component {
     additionalData: AdditionalData,
     callbacks: Callbacks
   ): Promise<PaymentIntent>;
+}
+
+export type HostedPage = {
+  id: string
+  type: string
+  url: string
+  state: string
+  embed: boolean
+  created_at: number
+  expires_at: number
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,16 @@ type OpenCheckoutOptions = {
   step?(currentStep: string): void
 }
 
+export type HostedPage = {
+  id: string
+  type: string
+  url: string
+  state: string
+  embed: boolean
+  created_at: number
+  expires_at: number
+}
+
 interface AddressDetails {
   first_name?: string;
   last_name?: string;
@@ -559,14 +569,4 @@ export interface Component {
     additionalData: AdditionalData,
     callbacks: Callbacks
   ): Promise<PaymentIntent>;
-}
-
-export type HostedPage = {
-  id: string
-  type: string
-  url: string
-  state: string
-  embed: boolean
-  created_at: number
-  expires_at: number
 }


### PR DESCRIPTION
The [openCheckout](https://www.chargebee.com/checkout-portal-docs/cbinstanceobj-api-ref.html#checkout-and-portal-integration) documentation shows most parameters as optional, and the `hostedPage` parameter requiring a Promise with a hosted page object to be returned.  This PR aligns the types with that documentation.