### PR TITLE
Export type of global Chargebee object + instance.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,8 +14,8 @@ import {
   Layout,
 } from './enums';
 
-declare var Chargebee: {
-  init(op: InitOptions): void;
+export declare var Chargebee: {
+  init(op: InitOptions): ChargebeeInstance;
   getInstance(): ChargebeeInstance;
 };
 
@@ -296,7 +296,7 @@ interface VatFunctions {
   validateVat(payload: VatValidationParams): VatValidationResponse;
 }
 
-type ChargebeeInstance = {
+export type ChargebeeInstance = {
   site: string;
   publishableKey: string;
   createComponent(


### PR DESCRIPTION
Trying to initialize the Chargebee global object in a Typescript environment, and getting complaints about it being an unknown type. This should allow me to import the type.